### PR TITLE
Fixup build on MacOS

### DIFF
--- a/Makefile.gcc6
+++ b/Makefile.gcc6
@@ -147,7 +147,7 @@ install_libm060bb32:
 # install the files for the given $(kind) into $(to)
 install_one:
 	mkdir -p $(PREFIX)/$(target)/libnix/lib/$(to)
-	rsync $(kind)/*.a $(PREFIX)/$(target)/libnix/lib/$(to) --exclude=$(kind)/libstubs.a
+	rsync $(kind)/*.a $(PREFIX)/$(target)/libnix/lib/$(to)
 	find $(kind) -maxdepth 1 -name "*.o" -exec cp {} $(PREFIX)/$(target)/libnix/lib/$(to) \;
 
 # startup stuff


### PR DESCRIPTION
The exclude had no effect on linux systems the file gets copied anyway On MacOS Seqoia with openrsync the file is excluded, breaking the build.

I'm not sure why the exclude is in the makefile, but it wasn't working before anyway

I haven't been able to build the full amiga-gcc yet on Mac, I get an error compiling gcc so I will wait to see what the user on EAB says (but EAB is down at time of writing...)