### PR TITLE
Fix ArgArray.c const-qualification error for GCC 15 (FindToolType)

### DIFF
--- a/sources/amiga/misc/ArgArray.c
+++ b/sources/amiga/misc/ArgArray.c
@@ -52,7 +52,7 @@ STRPTR ArgString(UBYTE **tt, STRPTR entry, STRPTR defstr)
 {
   STRPTR str;
 
-  if (!entry || !(str=FindToolType((STRPTR const *)tt,entry)))
+  if (entry && (str = FindToolType((CONST_STRPTR *)(const void *)tt, entry)))
     str=defstr;
   return str;
 }
@@ -61,7 +61,7 @@ LONG ArgInt(UBYTE **tt, STRPTR entry, long defval)
 {
   STRPTR str;
 
-  if (entry && (str=FindToolType((STRPTR const *)tt,entry)))
+  if (entry && (str = FindToolType((CONST_STRPTR *)(const void *)tt, entry)))
     StrToLong(str,&defval);
   return defval;
 }


### PR DESCRIPTION
GCC 15 enforces stricter pointer const-qualification rules.
This patch adds a safe (const void *) intermediary cast in ArgArray.c when calling FindToolType().
It resolves build errors under GCC 15 without changing behaviour.

Environment: Ubuntu WSL, GCC 15.2 Amiga Ports toolchain
Tested: Successful build and execution of libnix under AmigaPorts GCC 15.2.

Without this patch, GCC 15.2 fails on Make of Libnix
