### PR TITLE
revert stdio BUFSIZE to 1k

### DIFF
--- a/sources/headers/stdio.h
+++ b/sources/headers/stdio.h
@@ -97,7 +97,7 @@ typedef __FILE FILE;
 #ifndef NULL
 #define NULL ((void *)0l)
 #endif
-#define BUFSIZ 65536
+#define BUFSIZ 1024
 #define EOF (-1)
 #define SEEK_SET 0
 #define SEEK_CUR 1


### PR DESCRIPTION
64k causes stdio to gobble up memory quickly on low end systems. It's better to use setvbuf to increase the buffer where it's necessary on a case by case basis.